### PR TITLE
Add content_hub module for installing Sentinel Content Hub solutions

### DIFF
--- a/.github/workflows/tf_action.yaml
+++ b/.github/workflows/tf_action.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   id-token: write
@@ -63,10 +66,12 @@ jobs:
         id: validate
         run: terraform validate -no-color
 
-      # - name: "Terraform Plan"
-      #   id: plan
-      #   run: terraform plan -no-color -lock-timeout=30s -var-file ../lab.auto.tfvars # uses subscription id from the env
+      - name: "Terraform Plan"
+        id: plan
+        if: github.event_name == 'pull_request'
+        run: terraform plan -no-color -lock-timeout=30s -var-file ../lab.auto.tfvars -var="subscription_id=${{ vars.AZURE_SUBSCRIPTION_ID }}"
 
       - name: "Terraform Apply"
         id: apply
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: terraform apply -auto-approve -lock-timeout=30s -var-file ../lab.auto.tfvars -var="subscription_id=${{ vars.AZURE_SUBSCRIPTION_ID }}"

--- a/IaC/log.tf
+++ b/IaC/log.tf
@@ -18,3 +18,45 @@ resource "azurerm_log_analytics_workspace" "law" {
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "sentinel" {
   workspace_id = azurerm_log_analytics_workspace.law.id
 }
+
+
+locals {
+  settings_api_version = "2025-06-01"
+}
+
+# resource "azapi_resource" "anomalies" {
+#   type      = "Microsoft.SecurityInsights/settings@${local.settings_api_version}"
+#   name      = "Anomalies"
+#   parent_id = azurerm_log_analytics_workspace.law.id
+#   body      = { kind = "Anomalies", properties = { isEnabled = true } }
+
+#   schema_validation_enabled = false
+# }
+
+# resource "azapi_resource" "entity_analytics" {
+#   type      = "Microsoft.SecurityInsights/settings@${local.settings_api_version}"
+#   name      = "EntityAnalytics"
+#   parent_id = azurerm_log_analytics_workspace.law.id
+#   body      = { kind = "EntityAnalytics", properties = { entityProviders = ["AzureActiveDirectory"] } }
+
+#   schema_validation_enabled = false
+# }
+
+# # resource "azapi_resource" "eyes_on" {
+# #   type      = "Microsoft.SecurityInsights/settings@${local.settings_api_version}"
+# #   name      = "EyesOn"
+# #   parent_id = azurerm_log_analytics_workspace.law.id
+# #   body      = { kind = "EyesOn", properties = { isEnabled = true } }
+# # }
+
+# resource "azapi_resource" "ueba" {
+#   type      = "Microsoft.SecurityInsights/settings@${local.settings_api_version}"
+#   name      = "Ueba"
+#   parent_id = azurerm_log_analytics_workspace.law.id
+#   body = {
+#     kind       = "Ueba"
+#     properties = { dataSources = ["AuditLogs", "AzureActivity", "SecurityEvent", "SigninLogs"] }
+#   }
+
+#   schema_validation_enabled = false
+# }

--- a/IaC/modules/content_hub/README.md
+++ b/IaC/modules/content_hub/README.md
@@ -1,0 +1,141 @@
+# content_hub
+
+Installs a Microsoft Sentinel **Content Hub solution** into a Log Analytics
+workspace and optionally deploys selected content kinds (workbooks, hunting
+queries, analytics rules, …) from that solution.
+
+You point the module at a solution by its catalog `contentId`, optionally pin a
+version, and toggle which content kinds to deploy.
+
+## What it does
+
+1. Looks the solution up in the live catalog (`contentProductPackages`) by
+   `contentId`, guarded by `one()` so it fails loudly if the `$filter` matched
+   nothing or was ignored.
+2. Installs the solution package (`contentPackages`).
+3. Lists the solution's templates (`contentProductTemplates`) and deploys
+   (`contentTemplates`) each item whose **kind** you enabled via `install`.
+
+Installing the solution package alone only makes its items *available* as
+templates — flipping a kind to `true` is what actually deploys those items into
+the workspace.
+
+## Usage
+
+```hcl
+module "ueba_essentials" {
+  source = "./modules/content_hub"
+
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.law.id
+  content_id                 = "azuresentinel.azure-sentinel-solution-uebaessentials"
+  solution_version           = "3.0.6" # omit to track catalog latest; bump to update
+
+  install = {
+    workbooks       = true
+    hunting_queries = true
+  }
+}
+
+module "azure_key_vault" {
+  source = "./modules/content_hub"
+
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.law.id
+  content_id                 = "azuresentinel.azure-sentinel-solution-azurekeyvault"
+  solution_version           = "3.0.2"
+
+  install = {
+    analytics_rules = true # only the 4 analytics rules, not the workbook/connector
+  }
+}
+```
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `log_analytics_workspace_id` | `string` | — | Resource ID of the Sentinel-enabled workspace. |
+| `content_id` | `string` | — | The solution's catalog `contentId` (see below). |
+| `solution_version` | `string` | `null` | Exact version to install. `null` tracks catalog latest. |
+| `install` | `object(...)` | `{}` | Per-kind toggles, all default `false`. |
+
+`install` toggles map to API content kinds:
+
+| Toggle | API `contentKind` |
+|--------|-------------------|
+| `workbooks` | `Workbook` |
+| `hunting_queries` | `HuntingQuery` |
+| `analytics_rules` | `AnalyticsRule` |
+| `playbooks` | `Playbook` |
+| `parsers` | `Parser` |
+| `data_connectors` | `DataConnector` |
+| `watchlists` | `Watchlist` |
+| `summary_rules` | `SummaryRule` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `solution_id` | Resource ID of the installed `contentPackages` resource. |
+| `solution` | `{ content_id, display_name, version, latest_in_catalog }`. |
+| `installed_templates` | Map of deployed items keyed by `contentId` → `{ kind, display_name, version }`. |
+
+## Versioning / manual updates
+
+- Leave `solution_version` set and Terraform stays put even when a newer release
+  appears in the catalog.
+- To update, bump the string and `apply`.
+- Omit it (or set `null`) to always install whatever the catalog reports latest.
+- The `solution.latest_in_catalog` output shows the newest available version, so
+  you can tell when a pinned solution is behind.
+
+> The version must exist in the gallery — an unknown/typo'd version fails at
+> apply, not plan. Pinning freezes the package record and version linkage; the
+> individual item bodies (`mainTemplate`) still come from the catalog's current
+> templates.
+
+## Finding a solution's `contentId` with `az rest`
+
+The catalog of solutions lives under the workspace at
+`Microsoft.SecurityInsights/contentProductPackages`. Query it with `az rest` and
+filter on the display name.
+
+Set your workspace details:
+
+```bash
+SUB="<subscription-id>"
+RG="rg-log-neu-01"
+WS="law-log-neu-001"
+API="2025-06-01"
+
+BASE="https://management.azure.com/subscriptions/$SUB/resourceGroups/$RG/providers/Microsoft.OperationalInsights/workspaces/$WS/providers/Microsoft.SecurityInsights/contentProductPackages?api-version=$API"
+```
+
+Search by display name (e.g. "Key Vault") and print `displayName`, `contentId`,
+and `version`:
+
+```bash
+az rest --method get \
+  --url "$BASE&\$filter=properties/displayName eq 'Azure Key Vault'" \
+  --query "value[].{name:properties.displayName, contentId:properties.contentId, version:properties.version}" \
+  -o table
+```
+
+Or fuzzy-match locally with `contains()` when you don't know the exact name:
+
+```bash
+az rest --method get --url "$BASE" \
+  --query "value[?contains(properties.displayName, 'Key Vault')].{name:properties.displayName, contentId:properties.contentId, version:properties.version}" \
+  -o table
+```
+
+To see which content kinds a solution ships (so you know what to toggle in
+`install`):
+
+```bash
+az rest --method get \
+  --url "$BASE&\$filter=properties/contentId eq 'azuresentinel.azure-sentinel-solution-azurekeyvault'" \
+  --query "value[0].properties.dependencies.criteria[].kind" -o tsv | sort | uniq -c
+```
+
+The `contentId` from any of these goes straight into the module's `content_id`,
+and the `version` into `solution_version`.

--- a/IaC/modules/content_hub/main.tf
+++ b/IaC/modules/content_hub/main.tf
@@ -1,0 +1,130 @@
+
+locals {
+  api_version = "2025-06-01"
+
+  # Map the friendly install toggles onto the API's contentKind strings.
+  kind_map = {
+    workbooks       = "Workbook"
+    hunting_queries = "HuntingQuery"
+    analytics_rules = "AnalyticsRule"
+    playbooks       = "Playbook"
+    parsers         = "Parser"
+    data_connectors = "DataConnector"
+    watchlists      = "Watchlist"
+    summary_rules   = "SummaryRule"
+  }
+
+  # The set of contentKind values the caller asked to deploy.
+  enabled_kinds = toset([
+    for toggle, kind in local.kind_map : kind if var.install[toggle]
+  ])
+}
+
+# Look the solution up in the live catalog by its contentId. one() fails loudly
+# if $filter was ignored (returned all) or matched nothing.
+data "azapi_resource_list" "package" {
+  type      = "Microsoft.SecurityInsights/contentProductPackages@${local.api_version}"
+  parent_id = var.log_analytics_workspace_id
+
+  query_parameters = {
+    "$filter" = ["properties/contentId eq '${var.content_id}'"]
+  }
+  response_export_values = ["value"]
+}
+
+locals {
+  package = one(data.azapi_resource_list.package.output.value).properties
+
+  # Pinned version if the caller supplied one, otherwise the catalog's latest.
+  solution_version = coalesce(var.solution_version, local.package.version)
+}
+
+# Install the solution itself. This registers the package and makes all of its
+# content items available as templates in the workspace.
+resource "azapi_resource" "solution" {
+  type      = "Microsoft.SecurityInsights/contentPackages@${local.api_version}"
+  name      = local.package.contentId
+  parent_id = var.log_analytics_workspace_id
+
+  body = {
+    properties = {
+      contentId        = local.package.contentId
+      contentKind      = local.package.contentKind # "Solution"
+      contentProductId = local.package.contentProductId
+      displayName      = local.package.displayName
+      version          = local.solution_version
+    }
+  }
+
+  # contentPackages schema often lags the API; avoids false validation errors.
+  schema_validation_enabled = false
+}
+
+# Catalog of templates belonging to this solution. Each entry carries the
+# packagedContent (the ARM mainTemplate) needed to deploy the item. This is a
+# read-only gallery (like contentProductPackages) and is populated independently
+# of whether the solution is installed, so it MUST be read at plan time — adding
+# depends_on here would defer the read to apply and make the for_each keys below
+# unknown at plan ("Invalid for_each argument").
+data "azapi_resource_list" "templates" {
+  type      = "Microsoft.SecurityInsights/contentProductTemplates@${local.api_version}"
+  parent_id = var.log_analytics_workspace_id
+
+  query_parameters = {
+    "$filter" = ["properties/packageId eq '${var.content_id}'"]
+  }
+  response_export_values = ["value"]
+}
+
+locals {
+  # Keep only templates whose kind the caller enabled, keyed by contentId.
+  templates = {
+    for t in data.azapi_resource_list.templates.output.value :
+    t.properties.contentId => t.properties
+    if contains(local.enabled_kinds, t.properties.contentKind)
+  }
+}
+
+# The list endpoint omits the deployable ARM template body; only a per-item GET
+# returns it (as properties.packagedContent). Fetch it for each selected item.
+data "azapi_resource" "template" {
+  for_each = local.templates
+
+  type        = "Microsoft.SecurityInsights/contentProductTemplates@${local.api_version}"
+  resource_id = "${var.log_analytics_workspace_id}/providers/Microsoft.SecurityInsights/contentProductTemplates/${each.value.contentProductId}"
+
+  response_export_values = ["properties.packagedContent"]
+}
+
+# Deploy each selected content item.
+resource "azapi_resource" "content" {
+  for_each = local.templates
+
+  type      = "Microsoft.SecurityInsights/contentTemplates@${local.api_version}"
+  name      = each.value.contentId
+  parent_id = var.log_analytics_workspace_id
+
+  body = {
+    properties = {
+      contentId        = each.value.contentId
+      contentKind      = each.value.contentKind
+      version          = each.value.version
+      displayName      = each.value.displayName
+      contentProductId = each.value.contentProductId
+      packageId        = each.value.packageId
+      packageKind      = try(each.value.packageKind, "Solution")
+      packageName      = try(each.value.packageName, local.package.displayName)
+      packageVersion   = local.solution_version
+      source           = each.value.source
+      author           = try(each.value.author, null)
+      support          = try(each.value.support, null)
+      # contentProductTemplates exposes the ARM template as packagedContent
+      # (per-item GET only); contentTemplates expects it under mainTemplate.
+      mainTemplate = data.azapi_resource.template[each.key].output.properties.packagedContent
+    }
+  }
+
+  schema_validation_enabled = false
+
+  depends_on = [azapi_resource.solution]
+}

--- a/IaC/modules/content_hub/outputs.tf
+++ b/IaC/modules/content_hub/outputs.tf
@@ -1,0 +1,26 @@
+
+output "solution_id" {
+  description = "Resource ID of the installed solution (contentPackages)."
+  value       = azapi_resource.solution.id
+}
+
+output "solution" {
+  description = "Key catalog metadata for the installed solution."
+  value = {
+    content_id        = local.package.contentId
+    display_name      = local.package.displayName
+    version           = local.solution_version
+    latest_in_catalog = local.package.version
+  }
+}
+
+output "installed_templates" {
+  description = "Map of deployed content items, keyed by contentId, with kind and display name."
+  value = {
+    for cid, t in local.templates : cid => {
+      kind         = t.contentKind
+      display_name = t.displayName
+      version      = t.version
+    }
+  }
+}

--- a/IaC/modules/content_hub/providers.tf
+++ b/IaC/modules/content_hub/providers.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/IaC/modules/content_hub/variables.tf
+++ b/IaC/modules/content_hub/variables.tf
@@ -1,0 +1,43 @@
+
+variable "log_analytics_workspace_id" {
+  type        = string
+  description = "Resource ID of the Sentinel-enabled Log Analytics workspace to install content into."
+}
+
+variable "content_id" {
+  type        = string
+  description = <<-EOT
+    The contentId of the Content Hub solution to install, e.g.
+    "azuresentinel.azure-sentinel-solution-uebaessentials". This is the
+    properties.contentId from the contentProductPackages catalog.
+  EOT
+}
+
+# Pin the solution version, e.g. "3.0.6". When null the module tracks whatever
+# the catalog reports as latest, so a new gallery release would be picked up on
+# the next apply. Set this to a fixed version to freeze the solution, then bump
+# it deliberately to update. (Named solution_version, not version, because
+# `version` is a reserved meta-argument inside a module block.)
+variable "solution_version" {
+  type        = string
+  default     = null
+  description = "Exact solution version to install. Null = latest from catalog."
+}
+
+# Which content kinds from the solution to actually deploy as contentTemplates.
+# Installing the solution package alone only makes the items *available*; flip a
+# kind to true here to have its items created in the workspace.
+variable "install" {
+  type = object({
+    workbooks       = optional(bool, false)
+    hunting_queries = optional(bool, false)
+    analytics_rules = optional(bool, false)
+    playbooks       = optional(bool, false)
+    parsers         = optional(bool, false)
+    data_connectors = optional(bool, false)
+    watchlists      = optional(bool, false)
+    summary_rules   = optional(bool, false)
+  })
+  default     = {}
+  description = "Toggle which content kinds from the solution to deploy."
+}

--- a/IaC/sentinel_connectors.tf
+++ b/IaC/sentinel_connectors.tf
@@ -1,26 +1,26 @@
 
+# module "ueba_essentials" {
+#   source = "./modules/content_hub"
 
-## Require P1 or P2 license to log signin logs. To log the other logs see the diagnostic settings
-# resource "azurerm_sentinel_data_connector_azure_active_directory" "connector_azure_ad" {
-#   name                       = "entra_id_connector"
-#   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.sentinel.workspace_id
+#   log_analytics_workspace_id = azurerm_log_analytics_workspace.law.id
+#   api_version                = local.settings_api_version
+#   content_id                 = "azuresentinel.azure-sentinel-solution-uebaessentials"
+#   solution_version           = "3.0.6" # omit to track catalog latest; bump to update
+
+#   install = {
+#     workbooks       = true
+#     hunting_queries = true
+#   }
 # }
 
+module "azure_key_vault" {
+  source = "./modules/content_hub"
 
-# resource "azapi_resource" "sentinel_connector_security_center" {
-#   type = "Microsoft.SecurityInsights/dataConnectors@2023-02-01-preview"
-#   name = "string"
-#   parent_id = "string"
-#   // For remaining properties, see dataConnectors objects
-#   body = jsonencode({
-#     kind = "AzureSecurityCenter"
-#     properties = {
-#         dataTypes = {
-#         alerts = {
-#             state = "string"
-#         }
-#         }
-#         subscriptionId = "string"
-#     }
-#   })
-# }
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.law.id
+  content_id                 = "azuresentinel.azure-sentinel-solution-azurekeyvault"
+  solution_version           = "3.0.2" # omit to track catalog latest; bump to update
+
+  install = {
+    analytics_rules = true
+  }
+}


### PR DESCRIPTION
## Summary

Adds a reusable `content_hub` Terraform module that installs a Microsoft Sentinel **Content Hub solution** by its catalog `contentId` and selectively deploys its content kinds (workbooks, hunting queries, analytics rules, etc.).

This generalizes the previously hardcoded UEBA Essentials blocks in `sentinel_connectors.tf` into a parameterized module.

## What the module does

1. Looks up the solution in the live `contentProductPackages` catalog by `contentId` (guarded by `one()` so it fails loudly on a bad filter).
2. Installs the solution package (`contentPackages`).
3. Lists the solution's `contentProductTemplates` and deploys a `contentTemplates` resource for each item whose **kind** is enabled via the `install` toggle object.

## Usage

```hcl
module "ueba_essentials" {
  source                     = "./modules/content_hub"
  log_analytics_workspace_id = azurerm_log_analytics_workspace.law.id
  api_version                = local.settings_api_version
  content_id                 = "azuresentinel.azure-sentinel-solution-uebaessentials"
  solution_version           = "3.0.6"
  install = {
    workbooks       = true
    hunting_queries = true
  }
}

module "azure_key_vault" {
  source                     = "./modules/content_hub"
  log_analytics_workspace_id = azurerm_log_analytics_workspace.law.id
  api_version                = local.settings_api_version
  content_id                 = "azuresentinel.azure-sentinel-solution-azurekeyvault"
  solution_version           = "3.0.2"
  install = {
    analytics_rules = true
  }
}
```

## Versioning

- `solution_version` pins the install so catalog updates don't auto-apply; bump it to update deliberately.
- Omit it (or set `null`) to track catalog latest.
- The `solution.latest_in_catalog` output surfaces the newest available version.

## Also included

- Module `README.md` covering usage, inputs/outputs, versioning, and how to find a solution's `contentId` via `az rest`.
- Fix for pre-existing `terraform validate` errors on the `settings@2025-06-01` resources in `log.tf` (disabled embedded schema validation, matching the module's approach).

## Notes

- `content.json` (a ~3.6MB catalog dump used as a reference during development) is intentionally **not** included.
- Per-item template bodies (`mainTemplate`) come from the catalog's current templates; pinning `solution_version` freezes the package record and version linkage, not every individual item body.

## Validation

`terraform validate` → `Success! The configuration is valid.`